### PR TITLE
Add syntax "@_exported"

### DIFF
--- a/Sources/ContactStore/ContactStore.swift
+++ b/Sources/ContactStore/ContactStore.swift
@@ -22,7 +22,7 @@
 //  Created by Mykhailo Bondarenko on 23.03.2024.
 //
 
-import Contacts
+@_exported import Contacts
 
 /// A class providing a convenient interface for interacting with the Contacts framework.
 public final class ContactStore: ContactStoreProtocol {


### PR DESCRIPTION
# Title

Add syntax "@_exported"

## Motivation

The goal of this change is to simplify the import process of the Contacts framework across different files within the ContactStore library, by using @_exported import Contacts.

## Modifications

Added "@_exported import Contacts" to the class ContactStore of the main library module.

## Result

After this change, any file within the ContactStore library that imports the ContactStore module will automatically have access to the Contacts framework.
