### PR TITLE
Making fetch Contacts synchronously

### DIFF
--- a/Sources/ContactStore/ContactStoreProtocol.swift
+++ b/Sources/ContactStore/ContactStoreProtocol.swift
@@ -38,6 +38,8 @@ public protocol ContactStoreProtocol {
     func requestAccess() async throws -> Bool
     
     /// Fetches contacts from the store based on specified parameters.
+    /// This function should be called on a background thread to avoid blocking the UI,
+    /// especially when the contact database contains a large number of entries.
     ///
     /// - Parameters:
     ///   - keys: The keys to fetch for each contact.
@@ -49,7 +51,7 @@ public protocol ContactStoreProtocol {
         keysToFetch keys: [CNKeyDescriptor],
         order: CNContactSortOrder,
         unifyResults: Bool
-    ) async throws -> [CNContact]
+    ) throws -> [CNContact]
     
     /// Fetches contacts from the store based on a predicate.
     ///


### PR DESCRIPTION
# Fix priority inversion warning

## Motivation

During the process of fetching contacts from the contacts store, the warning 'Thread running at User-initiated quality-of-service class waiting on a lower QoS thread running at Background quality-of-service class. Investigate ways to avoid priority inversions' appears.

## Modifications

Making the function for fetching contacts synchronous and expanded the documentation to specify that the function must be called on a background thread.

## Result

The warning no longer appears.
